### PR TITLE
fix dbus long startup

### DIFF
--- a/snapcast-server/rootfs/etc/services.d/dbus/run
+++ b/snapcast-server/rootfs/etc/services.d/dbus/run
@@ -6,4 +6,7 @@
 
 bashio::log.info "Starting dbus-daemon..."
 
+# https://gitlab.freedesktop.org/dbus/dbus/-/issues/441#note_1721753
+ulimit -n 1024
+
 exec dbus-daemon --system --nofork


### PR DESCRIPTION
HAOS has a high ulimit causing dbus to take several minutes to initialize

https://gitlab.freedesktop.org/dbus/dbus/-/issues/441#note_1721753

Since we can't alter docker ulimits afaik this is the workaround I came up with