### PR TITLE
update librespot to 0.8.0

### DIFF
--- a/snapcast-server/Dockerfile
+++ b/snapcast-server/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base:18.1.0
 FROM $BUILD_FROM
 
-ARG LIBRESPOT_VERSION=0.7.0
+ARG LIBRESPOT_VERSION=0.8.0
 ARG GM_RENDER_RESURRECT_VERSION=v0.3
 
 # Add Runtime Dependencies
@@ -87,7 +87,7 @@ RUN apk del --no-cache --purge .build-dependencies \
                 /gmrender-resurrect
 
 # RUN apk add --no-cache librespot=0.6.0-r0 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
-RUN apk add --no-cache snapweb=0.9.1-r0 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add --no-cache snapweb=0.9.2-r0 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 RUN addgroup root audio
 

--- a/snapcast-server/config.yaml
+++ b/snapcast-server/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Snapcast server
-version: "0.4.4"
+version: "0.4.5"
 slug: snapcast-server
 description: Snapcast server with Spotify connect and DLNA Renderer support
 url: "https://github.com/DjFabFab/hassio-snapcast/tree/main/snapcast-server"


### PR DESCRIPTION
My librespot 0.7.0 was no longer working. With this update it works fine again on my installation. Hope this helps others.

On my own installation, I had to comment the last line in config.yaml to get the container rebuilt. Not sure if that is needed in this pull request, so I left it out.